### PR TITLE
Auto-publish new releases on pypi

### DIFF
--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -1,0 +1,27 @@
+name: Upload Python Package
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set up Python
+      uses: actions/setup-python@v1
+      with:
+        python-version: '3.x'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install setuptools wheel twine
+    - name: Build and publish
+      env:
+        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+      run: |
+        python setup.py sdist
+        twine check dist/*
+        twine upload --repository-url https://pypi.org/legacy/ dist/*


### PR DESCRIPTION
- Created pythonpublish.yml
- Added required PyPI secrets to the repository

Based on https://help.github.com/en/actions/automating-your-workflow-with-github-actions/using-python-with-github-actions#publishing-to-package-registries