### PR TITLE
Bump version to 0.1.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open('README.md') as readme:
 setup(
   name='max-training-framework',
   packages=find_packages(),
-  version='0.1.1',
+  version='0.1.2',
   license='Apache-2.0',
   description='Training framework for the Model Asset Exchange',
   long_description=README,


### PR DESCRIPTION
For delivery of #14 and #16 (pending). Will cut a new release for this version since it delivers important training fixes.